### PR TITLE
Add proof of concept notebook for zero-copy loading from HDF5

### DIFF
--- a/notebooks/h5_poc.ipynb
+++ b/notebooks/h5_poc.ipynb
@@ -1,0 +1,1217 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "26501644-69e5-4649-944a-79c892528c5c",
+   "metadata": {},
+   "source": [
+    "# Proof of concept for zero-copy loading from `.h5` files\n",
+    "\n",
+    "This notebook demonstrates loading the weights of PyTorch models directly from a memory-mapped file, without copying the weights into local process memory. Loading models this way should make loading much faster and allow for multiple processes to share the memory containing the weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "75bebfc6-2864-4fd8-a0b5-cbdf0717a965",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment if you need to install h5py\n",
+    "#!pip install h5py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e88861a7-0a17-41cf-ad10-26fe5fda41c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# imports go here\n",
+    "import h5py\n",
+    "import io\n",
+    "import mmap\n",
+    "import os\n",
+    "import psutil\n",
+    "import numpy as np\n",
+    "import pickle\n",
+    "import torch\n",
+    "import transformers\n",
+    "import zipfile\n",
+    "\n",
+    "from typing import Dict, Tuple, Union"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5459b8e-12a1-4d7f-a8c9-9952860cd8bc",
+   "metadata": {},
+   "source": [
+    "## Serialize the model\n",
+    "\n",
+    "We start by loading a copy of `bert-base-uncased`, then writing it to disk with PyTorch's built-in serialization. This operation creates a file `outputs/bert.pt`, which is actually a zip archive with a pickled graph of Python objects plus a single file per tensor containing tensor data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "74ecb090-29e8-4c6c-b642-8590c7552630",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Some weights of the model checkpoint at bert-base-uncased were not used when initializing BertModel: ['cls.predictions.bias', 'cls.predictions.decoder.weight', 'cls.seq_relationship.weight', 'cls.predictions.transform.dense.bias', 'cls.predictions.transform.dense.weight', 'cls.predictions.transform.LayerNorm.weight', 'cls.seq_relationship.bias', 'cls.predictions.transform.LayerNorm.bias']\n",
+      "- This IS expected if you are initializing BertModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
+      "- This IS NOT expected if you are initializing BertModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n"
+     ]
+    }
+   ],
+   "source": [
+    "bert = transformers.BertModel.\\\n",
+    "          from_pretrained(\"bert-base-uncased\")\n",
+    "torch.save(bert, \"outputs/bert.pt\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "942dd4ce-87ab-48c0-91b9-975bad7ec4f5",
+   "metadata": {},
+   "source": [
+    "## Convert to HDF5 format\n",
+    "\n",
+    "PyTorch's zipfile-based format is not amenable to zero-copy loading, because model weights are stored compressed. So we convert the zip file to [HDF5 format](https://www.hdfgroup.org/solutions/hdf5/). HDF5 stores binary data directly inside the file, uncompressed. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9eae2496-c48e-4cfa-9b7b-0bd1518fb04e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Copying 60813 bytes for \"archive/data.pkl\"\n",
+      "Copying 4096 bytes for \"archive/data/0\"\n",
+      "Copying 4096 bytes for \"archive/data/1\"\n",
+      "Copying 3072 bytes for \"archive/data/10\"\n",
+      "Copying 3072 bytes for \"archive/data/100\"\n",
+      "Copying 3072 bytes for \"archive/data/101\"\n",
+      "Copying 3072 bytes for \"archive/data/102\"\n",
+      "Copying 2359296 bytes for \"archive/data/103\"\n",
+      "Copying 3072 bytes for \"archive/data/104\"\n",
+      "Copying 2359296 bytes for \"archive/data/105\"\n",
+      "Copying 3072 bytes for \"archive/data/106\"\n",
+      "Copying 2359296 bytes for \"archive/data/107\"\n",
+      "Copying 3072 bytes for \"archive/data/108\"\n",
+      "Copying 2359296 bytes for \"archive/data/109\"\n",
+      "Copying 2359296 bytes for \"archive/data/11\"\n",
+      "Copying 3072 bytes for \"archive/data/110\"\n",
+      "Copying 3072 bytes for \"archive/data/111\"\n",
+      "Copying 3072 bytes for \"archive/data/112\"\n",
+      "Copying 9437184 bytes for \"archive/data/113\"\n",
+      "Copying 12288 bytes for \"archive/data/114\"\n",
+      "Copying 9437184 bytes for \"archive/data/115\"\n",
+      "Copying 3072 bytes for \"archive/data/116\"\n",
+      "Copying 3072 bytes for \"archive/data/117\"\n",
+      "Copying 3072 bytes for \"archive/data/118\"\n",
+      "Copying 2359296 bytes for \"archive/data/119\"\n",
+      "Copying 3072 bytes for \"archive/data/12\"\n",
+      "Copying 3072 bytes for \"archive/data/120\"\n",
+      "Copying 2359296 bytes for \"archive/data/121\"\n",
+      "Copying 3072 bytes for \"archive/data/122\"\n",
+      "Copying 2359296 bytes for \"archive/data/123\"\n",
+      "Copying 3072 bytes for \"archive/data/124\"\n",
+      "Copying 2359296 bytes for \"archive/data/125\"\n",
+      "Copying 3072 bytes for \"archive/data/126\"\n",
+      "Copying 3072 bytes for \"archive/data/127\"\n",
+      "Copying 3072 bytes for \"archive/data/128\"\n",
+      "Copying 9437184 bytes for \"archive/data/129\"\n",
+      "Copying 2359296 bytes for \"archive/data/13\"\n",
+      "Copying 12288 bytes for \"archive/data/130\"\n",
+      "Copying 9437184 bytes for \"archive/data/131\"\n",
+      "Copying 3072 bytes for \"archive/data/132\"\n",
+      "Copying 3072 bytes for \"archive/data/133\"\n",
+      "Copying 3072 bytes for \"archive/data/134\"\n",
+      "Copying 2359296 bytes for \"archive/data/135\"\n",
+      "Copying 3072 bytes for \"archive/data/136\"\n",
+      "Copying 2359296 bytes for \"archive/data/137\"\n",
+      "Copying 3072 bytes for \"archive/data/138\"\n",
+      "Copying 2359296 bytes for \"archive/data/139\"\n",
+      "Copying 3072 bytes for \"archive/data/14\"\n",
+      "Copying 3072 bytes for \"archive/data/140\"\n",
+      "Copying 2359296 bytes for \"archive/data/141\"\n",
+      "Copying 3072 bytes for \"archive/data/142\"\n",
+      "Copying 3072 bytes for \"archive/data/143\"\n",
+      "Copying 3072 bytes for \"archive/data/144\"\n",
+      "Copying 9437184 bytes for \"archive/data/145\"\n",
+      "Copying 12288 bytes for \"archive/data/146\"\n",
+      "Copying 9437184 bytes for \"archive/data/147\"\n",
+      "Copying 3072 bytes for \"archive/data/148\"\n",
+      "Copying 3072 bytes for \"archive/data/149\"\n",
+      "Copying 3072 bytes for \"archive/data/15\"\n",
+      "Copying 3072 bytes for \"archive/data/150\"\n",
+      "Copying 2359296 bytes for \"archive/data/151\"\n",
+      "Copying 3072 bytes for \"archive/data/152\"\n",
+      "Copying 2359296 bytes for \"archive/data/153\"\n",
+      "Copying 3072 bytes for \"archive/data/154\"\n",
+      "Copying 2359296 bytes for \"archive/data/155\"\n",
+      "Copying 3072 bytes for \"archive/data/156\"\n",
+      "Copying 2359296 bytes for \"archive/data/157\"\n",
+      "Copying 3072 bytes for \"archive/data/158\"\n",
+      "Copying 3072 bytes for \"archive/data/159\"\n",
+      "Copying 3072 bytes for \"archive/data/16\"\n",
+      "Copying 3072 bytes for \"archive/data/160\"\n",
+      "Copying 9437184 bytes for \"archive/data/161\"\n",
+      "Copying 12288 bytes for \"archive/data/162\"\n",
+      "Copying 9437184 bytes for \"archive/data/163\"\n",
+      "Copying 3072 bytes for \"archive/data/164\"\n",
+      "Copying 3072 bytes for \"archive/data/165\"\n",
+      "Copying 3072 bytes for \"archive/data/166\"\n",
+      "Copying 2359296 bytes for \"archive/data/167\"\n",
+      "Copying 3072 bytes for \"archive/data/168\"\n",
+      "Copying 2359296 bytes for \"archive/data/169\"\n",
+      "Copying 9437184 bytes for \"archive/data/17\"\n",
+      "Copying 3072 bytes for \"archive/data/170\"\n",
+      "Copying 2359296 bytes for \"archive/data/171\"\n",
+      "Copying 3072 bytes for \"archive/data/172\"\n",
+      "Copying 2359296 bytes for \"archive/data/173\"\n",
+      "Copying 3072 bytes for \"archive/data/174\"\n",
+      "Copying 3072 bytes for \"archive/data/175\"\n",
+      "Copying 3072 bytes for \"archive/data/176\"\n",
+      "Copying 9437184 bytes for \"archive/data/177\"\n",
+      "Copying 12288 bytes for \"archive/data/178\"\n",
+      "Copying 9437184 bytes for \"archive/data/179\"\n",
+      "Copying 12288 bytes for \"archive/data/18\"\n",
+      "Copying 3072 bytes for \"archive/data/180\"\n",
+      "Copying 3072 bytes for \"archive/data/181\"\n",
+      "Copying 3072 bytes for \"archive/data/182\"\n",
+      "Copying 2359296 bytes for \"archive/data/183\"\n",
+      "Copying 3072 bytes for \"archive/data/184\"\n",
+      "Copying 2359296 bytes for \"archive/data/185\"\n",
+      "Copying 3072 bytes for \"archive/data/186\"\n",
+      "Copying 2359296 bytes for \"archive/data/187\"\n",
+      "Copying 3072 bytes for \"archive/data/188\"\n",
+      "Copying 2359296 bytes for \"archive/data/189\"\n",
+      "Copying 9437184 bytes for \"archive/data/19\"\n",
+      "Copying 3072 bytes for \"archive/data/190\"\n",
+      "Copying 3072 bytes for \"archive/data/191\"\n",
+      "Copying 3072 bytes for \"archive/data/192\"\n",
+      "Copying 9437184 bytes for \"archive/data/193\"\n",
+      "Copying 12288 bytes for \"archive/data/194\"\n",
+      "Copying 9437184 bytes for \"archive/data/195\"\n",
+      "Copying 3072 bytes for \"archive/data/196\"\n",
+      "Copying 3072 bytes for \"archive/data/197\"\n",
+      "Copying 3072 bytes for \"archive/data/198\"\n",
+      "Copying 2359296 bytes for \"archive/data/199\"\n",
+      "Copying 93763584 bytes for \"archive/data/2\"\n",
+      "Copying 3072 bytes for \"archive/data/20\"\n",
+      "Copying 3072 bytes for \"archive/data/200\"\n",
+      "Copying 3072 bytes for \"archive/data/21\"\n",
+      "Copying 3072 bytes for \"archive/data/22\"\n",
+      "Copying 2359296 bytes for \"archive/data/23\"\n",
+      "Copying 3072 bytes for \"archive/data/24\"\n",
+      "Copying 2359296 bytes for \"archive/data/25\"\n",
+      "Copying 3072 bytes for \"archive/data/26\"\n",
+      "Copying 2359296 bytes for \"archive/data/27\"\n",
+      "Copying 3072 bytes for \"archive/data/28\"\n",
+      "Copying 2359296 bytes for \"archive/data/29\"\n",
+      "Copying 1572864 bytes for \"archive/data/3\"\n",
+      "Copying 3072 bytes for \"archive/data/30\"\n",
+      "Copying 3072 bytes for \"archive/data/31\"\n",
+      "Copying 3072 bytes for \"archive/data/32\"\n",
+      "Copying 9437184 bytes for \"archive/data/33\"\n",
+      "Copying 12288 bytes for \"archive/data/34\"\n",
+      "Copying 9437184 bytes for \"archive/data/35\"\n",
+      "Copying 3072 bytes for \"archive/data/36\"\n",
+      "Copying 3072 bytes for \"archive/data/37\"\n",
+      "Copying 3072 bytes for \"archive/data/38\"\n",
+      "Copying 2359296 bytes for \"archive/data/39\"\n",
+      "Copying 6144 bytes for \"archive/data/4\"\n",
+      "Copying 3072 bytes for \"archive/data/40\"\n",
+      "Copying 2359296 bytes for \"archive/data/41\"\n",
+      "Copying 3072 bytes for \"archive/data/42\"\n",
+      "Copying 2359296 bytes for \"archive/data/43\"\n",
+      "Copying 3072 bytes for \"archive/data/44\"\n",
+      "Copying 2359296 bytes for \"archive/data/45\"\n",
+      "Copying 3072 bytes for \"archive/data/46\"\n",
+      "Copying 3072 bytes for \"archive/data/47\"\n",
+      "Copying 3072 bytes for \"archive/data/48\"\n",
+      "Copying 9437184 bytes for \"archive/data/49\"\n",
+      "Copying 3072 bytes for \"archive/data/5\"\n",
+      "Copying 12288 bytes for \"archive/data/50\"\n",
+      "Copying 9437184 bytes for \"archive/data/51\"\n",
+      "Copying 3072 bytes for \"archive/data/52\"\n",
+      "Copying 3072 bytes for \"archive/data/53\"\n",
+      "Copying 3072 bytes for \"archive/data/54\"\n",
+      "Copying 2359296 bytes for \"archive/data/55\"\n",
+      "Copying 3072 bytes for \"archive/data/56\"\n",
+      "Copying 2359296 bytes for \"archive/data/57\"\n",
+      "Copying 3072 bytes for \"archive/data/58\"\n",
+      "Copying 2359296 bytes for \"archive/data/59\"\n",
+      "Copying 3072 bytes for \"archive/data/6\"\n",
+      "Copying 3072 bytes for \"archive/data/60\"\n",
+      "Copying 2359296 bytes for \"archive/data/61\"\n",
+      "Copying 3072 bytes for \"archive/data/62\"\n",
+      "Copying 3072 bytes for \"archive/data/63\"\n",
+      "Copying 3072 bytes for \"archive/data/64\"\n",
+      "Copying 9437184 bytes for \"archive/data/65\"\n",
+      "Copying 12288 bytes for \"archive/data/66\"\n",
+      "Copying 9437184 bytes for \"archive/data/67\"\n",
+      "Copying 3072 bytes for \"archive/data/68\"\n",
+      "Copying 3072 bytes for \"archive/data/69\"\n",
+      "Copying 2359296 bytes for \"archive/data/7\"\n",
+      "Copying 3072 bytes for \"archive/data/70\"\n",
+      "Copying 2359296 bytes for \"archive/data/71\"\n",
+      "Copying 3072 bytes for \"archive/data/72\"\n",
+      "Copying 2359296 bytes for \"archive/data/73\"\n",
+      "Copying 3072 bytes for \"archive/data/74\"\n",
+      "Copying 2359296 bytes for \"archive/data/75\"\n",
+      "Copying 3072 bytes for \"archive/data/76\"\n",
+      "Copying 2359296 bytes for \"archive/data/77\"\n",
+      "Copying 3072 bytes for \"archive/data/78\"\n",
+      "Copying 3072 bytes for \"archive/data/79\"\n",
+      "Copying 3072 bytes for \"archive/data/8\"\n",
+      "Copying 3072 bytes for \"archive/data/80\"\n",
+      "Copying 9437184 bytes for \"archive/data/81\"\n",
+      "Copying 12288 bytes for \"archive/data/82\"\n",
+      "Copying 9437184 bytes for \"archive/data/83\"\n",
+      "Copying 3072 bytes for \"archive/data/84\"\n",
+      "Copying 3072 bytes for \"archive/data/85\"\n",
+      "Copying 3072 bytes for \"archive/data/86\"\n",
+      "Copying 2359296 bytes for \"archive/data/87\"\n",
+      "Copying 3072 bytes for \"archive/data/88\"\n",
+      "Copying 2359296 bytes for \"archive/data/89\"\n",
+      "Copying 2359296 bytes for \"archive/data/9\"\n",
+      "Copying 3072 bytes for \"archive/data/90\"\n",
+      "Copying 2359296 bytes for \"archive/data/91\"\n",
+      "Copying 3072 bytes for \"archive/data/92\"\n",
+      "Copying 2359296 bytes for \"archive/data/93\"\n",
+      "Copying 3072 bytes for \"archive/data/94\"\n",
+      "Copying 3072 bytes for \"archive/data/95\"\n",
+      "Copying 3072 bytes for \"archive/data/96\"\n",
+      "Copying 9437184 bytes for \"archive/data/97\"\n",
+      "Copying 12288 bytes for \"archive/data/98\"\n",
+      "Copying 9437184 bytes for \"archive/data/99\"\n",
+      "Copying 2 bytes for \"archive/version\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "h5_file_name = 'outputs/bert.h5'\n",
+    "\n",
+    "if os.path.exists(h5_file_name):\n",
+    "    os.unlink(h5_file_name)\n",
+    "\n",
+    "with zipfile.ZipFile('outputs/bert.pt', 'r') as zip_file:\n",
+    "    with h5py.File(h5_file_name, 'w') as h5_file:\n",
+    "        for info in zip_file.infolist():\n",
+    "            with zip_file.open(info.filename, 'r') as f:\n",
+    "                file_data = f.read()\n",
+    "                print(f'Copying {len(file_data)} bytes for \"{info.filename}\"')\n",
+    "                dataset = h5_file.create_dataset(\n",
+    "                    info.filename, data=np.frombuffer(file_data, dtype=np.byte))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0573f2ff-95d0-4dfe-b2ed-f78635c9fe07",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-rw-r--r--  1 freiss  staff   418M Sep  2 15:13 outputs/bert.h5\n",
+      "-rw-r--r--  1 freiss  staff   418M Sep  2 15:13 outputs/bert.pt\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls -lh outputs/bert*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49ac8c71-350a-4a07-bfab-e9a145436ce5",
+   "metadata": {},
+   "source": [
+    "## Read tensors from HDF5 files without copying data\n",
+    "\n",
+    "If you write data to an HDF5 file with the `h5py` library's default settings, the data for each dataset (i.e. multidimensional array) will end up in a contiguous range of the file on disk. If we later memory-map the file, we can access this data directly without copying.\n",
+    "\n",
+    "Let's start with the process for loading a single tensor.\n",
+    "Some of the code here is inspired by [this gist](https://gist.github.com/maartenbreddels/09e1da79577151e5f7fec660c209f06e) from \n",
+    "Maarten Breddels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4635faad-2470-4243-89bc-eea58e3676b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original tensor data:\n",
+      "tensor([[-0.0102, -0.0615, -0.0265,  ..., -0.0199, -0.0372, -0.0098],\n",
+      "        [-0.0117, -0.0600, -0.0323,  ..., -0.0168, -0.0401, -0.0107],\n",
+      "        [-0.0198, -0.0627, -0.0326,  ..., -0.0165, -0.0420, -0.0032],\n",
+      "        ...,\n",
+      "        [-0.0218, -0.0556, -0.0135,  ..., -0.0043, -0.0151, -0.0249],\n",
+      "        [-0.0462, -0.0565, -0.0019,  ...,  0.0157, -0.0139, -0.0095],\n",
+      "        [ 0.0015, -0.0821, -0.0160,  ..., -0.0081, -0.0475,  0.0753]])\n",
+      "Data after zero-copy loading:\n",
+      "tensor([[-0.0102, -0.0615, -0.0265,  ..., -0.0199, -0.0372, -0.0098],\n",
+      "        [-0.0117, -0.0600, -0.0323,  ..., -0.0168, -0.0401, -0.0107],\n",
+      "        [-0.0198, -0.0627, -0.0326,  ..., -0.0165, -0.0420, -0.0032],\n",
+      "        ...,\n",
+      "        [-0.0218, -0.0556, -0.0135,  ..., -0.0043, -0.0151, -0.0249],\n",
+      "        [-0.0462, -0.0565, -0.0019,  ...,  0.0157, -0.0139, -0.0095],\n",
+      "        [ 0.0015, -0.0821, -0.0160,  ..., -0.0081, -0.0475,  0.0753]])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/bd/k5pyhn0130708d7y9q2pjj380000gn/T/ipykernel_15056/3094063076.py:25: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /Users/runner/work/pytorch/pytorch/pytorch/torch/csrc/utils/tensor_numpy.cpp:178.)\n",
+      "  tensor = torch.as_tensor(array_view)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Pick the first tensor in the file that isn't filled with zeros\n",
+    "tensor_data_loc = 'archive/data/2'\n",
+    "original_tensor_name = 'embeddings.word_embeddings.weight'\n",
+    "tensor_shape = bert.state_dict()[original_tensor_name].shape\n",
+    "\n",
+    "# Read the offset and size of the array\n",
+    "with h5py.File(h5_file_name, 'r') as h5_file:\n",
+    "    dataset = h5_file[tensor_data_loc]\n",
+    "    offset = dataset.id.get_offset()\n",
+    "    length = dataset.id.shape[0]\n",
+    "\n",
+    "# Memory-map the file once.\n",
+    "raw_file = open(h5_file_name,'rb')\n",
+    "mmap_buffer = mmap.mmap(raw_file.fileno(), 0, access=mmap.ACCESS_READ)\n",
+    "\n",
+    "# Wrap a portion of the memory-mapped buffer in a Numpy array, without\n",
+    "# copying data.\n",
+    "raw_array = np.frombuffer(mmap_buffer, dtype=np.byte, count=length, \n",
+    "                          offset=offset)\n",
+    "\n",
+    "# Add shape and dtype information back in, without copying data\n",
+    "array_view = raw_array.view(np.float32).reshape(tensor_shape)\n",
+    "\n",
+    "# Wrap the Numpy array in a PyTorch tensor, without copying data\n",
+    "tensor = torch.as_tensor(array_view)\n",
+    "\n",
+    "# Compare the resulting data against the original\n",
+    "print('Original tensor data:')\n",
+    "print(bert.state_dict()[original_tensor_name])\n",
+    "print('Data after zero-copy loading:')\n",
+    "print(tensor)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b51da1a-8ed7-45e3-988f-da314b1b8406",
+   "metadata": {},
+   "source": [
+    "We can power up this approach to read all of the weights at once, without copying data.\n",
+    "\n",
+    "But first we'll need to work around a limitation of the file format: Reading offset metadata for the datasets inside an HDF5 file from Python code takes a surprisingly long time. If we use the `h5py` library's Pythonic API..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7696eebf-1edc-46c1-8a18-b76c59509846",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 26.9 ms, sys: 3.63 ms, total: 30.5 ms\n",
+      "Wall time: 28.9 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "with h5py.File(h5_file_name, 'r') as h5_file:\n",
+    "    # PyTorch stores all tensors under the prefix \"archive/data\"\n",
+    "    tensor_data_group = h5_file['archive/data']\n",
+    "    name_to_offset_and_len = {\n",
+    "        name: (data.id.get_offset(), data.id.shape[0])\n",
+    "        for name, data in tensor_data_group.items()\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5245ccd-4d1c-4771-bb99-222fd25686c0",
+   "metadata": {},
+   "source": [
+    "...then reading this data takes 25-30 msec. That's much too long. \n",
+    "\n",
+    "If we drop down to `h5py`'s low-level API..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b2c79bf3-f3f9-4cef-8e98-65a090d81291",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 10.1 ms, sys: 2.22 ms, total: 12.3 ms\n",
+      "Wall time: 11.4 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time \n",
+    "\n",
+    "# Measure how long it takes to read offsets with h5py's low-level API\n",
+    "name_to_offset_and_len = {}\n",
+    "file_id = h5py.h5f.open(h5_file_name.encode('utf8'), h5py.h5f.ACC_RDONLY)\n",
+    "group_id = h5py.h5g.open(file_id, b'archive/data')\n",
+    "for group_name in group_id:\n",
+    "    dataset_id = h5py.h5d.open(group_id, group_name)\n",
+    "    offset = dataset_id.get_offset()\n",
+    "    length = dataset_id.shape[0]\n",
+    "    name_to_offset_and_len[group_name.decode('utf8')] = \\\n",
+    "        (offset, length)\n",
+    "\n",
+    "file_id.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b79b4cab-7fdc-4ed4-9029-74ee8931afc7",
+   "metadata": {},
+   "source": [
+    "...then reading the metadata takes 8-10 msec, which is still too long.\n",
+    "\n",
+    "So instead we'll stuff all the lengths and offsets into an HDF5 dataset and store that dataset in the file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b7e04534-bcbe-4e9a-b41e-55032ae7a6bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if os.path.exists(h5_file_name):\n",
+    "    os.unlink(h5_file_name)\n",
+    "    \n",
+    "offset_info = []  # type: Tuple[int, int, int]\n",
+    "\n",
+    "with zipfile.ZipFile('outputs/bert.pt', 'r') as zip_file:\n",
+    "    with h5py.File(h5_file_name, 'w') as h5_file:\n",
+    "        for info in zip_file.infolist():\n",
+    "            with zip_file.open(info.filename, 'r') as f:\n",
+    "                file_data = f.read()\n",
+    "                dataset = h5_file.create_dataset(\n",
+    "                    info.filename, data=np.frombuffer(file_data, dtype=np.byte))\n",
+    "                if info.filename.startswith('archive/data/'):\n",
+    "                    # Tensor storage data file. Remember ID, offset, and length\n",
+    "                    # Conveniently, all the IDs are integers, so we can store them\n",
+    "                    # as such.\n",
+    "                    storage_id_str = info.filename.split('/')[-1]\n",
+    "                    storage_id = int(storage_id_str)\n",
+    "                    offset = dataset.id.get_offset()\n",
+    "                    length = dataset.id.shape[0]\n",
+    "                    offset_info.append((storage_id, offset, length))\n",
+    "        # Write table of storage offsets\n",
+    "        _ = h5_file.create_dataset('offsets_table',\n",
+    "                                   data=np.array(offset_info))\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dacaa9d6-b31a-4130-aa3b-4a691d4e6b06",
+   "metadata": {},
+   "source": [
+    "Now we can recover the offset information more quickly by reading the table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "59818717-2979-4be1-93de-81666bceb541",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.43 ms, sys: 621 µs, total: 2.05 ms\n",
+      "Wall time: 1.62 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "with h5py.File(h5_file_name, 'r') as h5_file:\n",
+    "    offset_info_dataset = h5_file['offsets_table']\n",
+    "\n",
+    "    # Dump into a Numpy array because that method is much faster than \n",
+    "    # iterating over the Python object.\n",
+    "    offset_info_array = np.zeros(offset_info_dataset.shape, dtype='int64')\n",
+    "    offset_info_dataset.read_direct(offset_info_array)\n",
+    "\n",
+    "name_to_offset_and_len = {\n",
+    "    str(row[0]): (row[1], row[2]) for row in offset_info_array\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7aa069e8-27d0-4c96-9075-86f24fb65610",
+   "metadata": {},
+   "source": [
+    "Reading the offsets info in this way takes 1.5-2 msec, which is good enough for now."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81b4c270-dde9-4cd4-acfd-a5f5814dbd18",
+   "metadata": {},
+   "source": [
+    "Now we can read the all weights into Numpy arrays without copying data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "5e190afc-4dd6-47c7-ba8a-8fbb47a3a1fc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 321 µs, sys: 14 µs, total: 335 µs\n",
+      "Wall time: 340 µs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "name_to_array = {\n",
+    "    name: \n",
+    "    np.frombuffer(\n",
+    "        # Memory map buffer from the previous cell\n",
+    "        mmap_buffer, \n",
+    "        dtype=np.byte, count=tup[1], offset=tup[0])\n",
+    "    for name, tup in name_to_offset_and_len.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6358e43-eab1-46f0-b71f-a22619dfb4c2",
+   "metadata": {},
+   "source": [
+    "Reading all of the weights takes less than a millisecond. Let's verify that the data comes back correct."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "b8b8edf0-152b-4c67-8082-0c4925d881f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[-0.0102, -0.0615, -0.0265,  ..., -0.0199, -0.0372, -0.0098],\n",
+       "        [-0.0117, -0.0600, -0.0323,  ..., -0.0168, -0.0401, -0.0107],\n",
+       "        [-0.0198, -0.0627, -0.0326,  ..., -0.0165, -0.0420, -0.0032],\n",
+       "        ...,\n",
+       "        [-0.0218, -0.0556, -0.0135,  ..., -0.0043, -0.0151, -0.0249],\n",
+       "        [-0.0462, -0.0565, -0.0019,  ...,  0.0157, -0.0139, -0.0095],\n",
+       "        [ 0.0015, -0.0821, -0.0160,  ..., -0.0081, -0.0475,  0.0753]])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "array_view_2 = name_to_array['2'].view(np.float32).reshape(tensor_shape)\n",
+    "torch.as_tensor(array_view_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e7c1826-7af2-417c-9770-73a4b62ab59e",
+   "metadata": {},
+   "source": [
+    "We can do the same to directly create PyTorch tensors without copying data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "9d3eb915-b1b1-4ca1-a3e7-a8a40652e71b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 612 µs, sys: 73 µs, total: 685 µs\n",
+      "Wall time: 649 µs\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<timed exec>:3: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /Users/runner/work/pytorch/pytorch/pytorch/torch/csrc/utils/tensor_new.cpp:1111.)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "name_to_tensor = {\n",
+    "    name: \n",
+    "    torch.frombuffer(\n",
+    "        # Memory map buffer from the previous cell\n",
+    "        mmap_buffer, \n",
+    "        dtype=torch.int8, count=tup[1], offset=tup[0])\n",
+    "    for name, tup in name_to_offset_and_len.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "de5fff95-604f-41cc-b10a-0fc887e301c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[-0.0102, -0.0615, -0.0265,  ..., -0.0199, -0.0372, -0.0098],\n",
+       "        [-0.0117, -0.0600, -0.0323,  ..., -0.0168, -0.0401, -0.0107],\n",
+       "        [-0.0198, -0.0627, -0.0326,  ..., -0.0165, -0.0420, -0.0032],\n",
+       "        ...,\n",
+       "        [-0.0218, -0.0556, -0.0135,  ..., -0.0043, -0.0151, -0.0249],\n",
+       "        [-0.0462, -0.0565, -0.0019,  ...,  0.0157, -0.0139, -0.0095],\n",
+       "        [ 0.0015, -0.0821, -0.0160,  ..., -0.0081, -0.0475,  0.0753]])"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "name_to_tensor['2'].view(torch.float32).reshape(tensor_shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94ee2517-6e7b-4b5f-a61c-2676a61f296d",
+   "metadata": {},
+   "source": [
+    "## Deserialize entire models\n",
+    "\n",
+    "Now that we know how load weights directly from an HDF5 file, let's try and redo the `torch.load()` function's internals to use this mechanism. `torch.load()` doesn't actually restore tensors. The function leaves restoration of the `Tensor` objects to `pickle` and focuses on restoring the `_TypedStorage` objects where the tensors' data are kept.\n",
+    "\n",
+    "Let's start by redoing the loading code above so that, instead of loading up tensors, it creates storage objects for the tensors. The obvious way to do this would be with the built-in `torch.<dtype>Storage.from_buffer()` class methods, but unfortunately those methods copy data, as evidenced by the amount of time the following cell takes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "3816ab02-39c7-4b8c-8170-825fd89317da",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 285 ms, sys: 149 ms, total: 434 ms\n",
+      "Wall time: 432 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# This doesn't work; copies data \n",
+    "name_to_storage = {\n",
+    "    name: \n",
+    "    torch.ByteStorage.from_buffer(\n",
+    "        mmap_buffer, \n",
+    "        count=tup[1], offset=tup[0])\n",
+    "    for name, tup in name_to_offset_and_len.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c06c8cd6-45fe-4370-83ee-dc6dbec1eea9",
+   "metadata": {},
+   "source": [
+    "Falling back to the internal `_UntypedStorage` class also doesn't work; the `from_buffer()` method of that class also copies data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "69257801-896a-49af-911b-5da278a8318b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 195 ms, sys: 126 ms, total: 321 ms\n",
+      "Wall time: 319 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# This doesn't work; copies data\n",
+    "name_to_storage = {\n",
+    "    name: \n",
+    "    torch._UntypedStorage.from_buffer(\n",
+    "        mmap_buffer,\n",
+    "        dtype=torch.int8,\n",
+    "        count=tup[1], offset=tup[0])\n",
+    "    for name, tup in name_to_offset_and_len.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e173160-a22b-455c-836a-b0abce54d6a3",
+   "metadata": {},
+   "source": [
+    "What we can do instead is to use `torch.frombuffer()` to create `Tensor` objects, then drill down to their storage objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "d21558b3-ed99-4a88-90c6-79965a95c2ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "912 µs ± 4.84 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def make_name_to_storage():\n",
+    "    return {\n",
+    "        name: \n",
+    "        torch.frombuffer(\n",
+    "            mmap_buffer, \n",
+    "            dtype=torch.int8, count=tup[1], offset=tup[0]).storage()\n",
+    "        for name, tup in name_to_offset_and_len.items()\n",
+    "    }\n",
+    "\n",
+    "# The %%time magic is unreliable on this code for some reason, so use %timeit\n",
+    "%timeit make_name_to_storage()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c5ec4a2-264e-4b2e-8f86-2cecbede5db4",
+   "metadata": {},
+   "source": [
+    "Now we're ready to modify a copy of `torch.serialization._load()` (the primary implementation of `torch.load()`) such that it loads from an HDF5 file and doesn't copy any tensor data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "055019be-2e0d-4e1a-a992-a68d925b6a55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Function copied from torch/serialization.py\n",
+    "def _maybe_decode_ascii(bytes_str: Union[bytes, str]) -> str:\n",
+    "    if isinstance(bytes_str, bytes):\n",
+    "        return bytes_str.decode('ascii')\n",
+    "    return bytes_str\n",
+    "\n",
+    "\n",
+    "def zero_copy_load(h5_file, pickle_module=pickle, pickle_file='data.pkl', **pickle_load_args):\n",
+    "    \"\"\"\n",
+    "    Modified version of :func:`torch.serialization._load()` with the following changes:\n",
+    "    \n",
+    "    * Loads from an HDF5 file instead of a zip file\n",
+    "    * Loads tensors without copying data\n",
+    "    * Doesn't support restoring data to non-CPU devices\n",
+    "    \n",
+    "    :param h5_file: Location of a serialized PyTorch model written with \n",
+    "                    :func:`torch.save()` and then directly converted from zip to \n",
+    "                    HDF5 format.\n",
+    "    :param pickle_module: Implementation of the Pickle prototol that was used in\n",
+    "                          the original call to :func:`torch.save()`\n",
+    "    :param pickle_load_args: Additional arguments to pass to the serialization library                      \n",
+    "    \"\"\"\n",
+    "    loaded_storages = {}\n",
+    "    \n",
+    "    # Extract the pickled model and the byte offsets of tensor data from the HDF5 file\n",
+    "    with h5py.File(h5_file_name, 'r') as h5_file:\n",
+    "        offset_info_dataset = h5_file['offsets_table']\n",
+    "        offset_info_array = np.zeros(offset_info_dataset.shape, dtype='int64')\n",
+    "        offset_info_dataset.read_direct(offset_info_array)\n",
+    "        \n",
+    "        pickled_data_dataset = h5_file[f'archive/{pickle_file}']\n",
+    "        pickled_data_array = np.zeros(pickled_data_dataset.shape, dtype='byte')\n",
+    "        pickled_data_dataset.read_direct(pickled_data_array)\n",
+    "\n",
+    "    key_to_offset = {\n",
+    "        str(row[0]): row[1] for row in offset_info_array\n",
+    "    }\n",
+    "    \n",
+    "    # Memory-map the entire file in read-only mode\n",
+    "    raw_file = open(h5_file_name, 'rb')\n",
+    "    mmap_buffer = mmap.mmap(raw_file.fileno(), 0, \n",
+    "                            access=mmap.ACCESS_READ)\n",
+    "\n",
+    "    # Define callbacks for deserialization of tensor storage\n",
+    "    def load_tensor(dtype, numel, key, location):\n",
+    "        # In spite of its name (retained from original PyTorch code), this callback\n",
+    "        # doesn't load the Tensor object but instead loads the tensor's backing \n",
+    "        # TypedStorage object.\n",
+    "        offset = key_to_offset[key]\n",
+    "        loaded_storages[key] = (\n",
+    "            torch.frombuffer(mmap_buffer, dtype=dtype, count=numel, offset=offset)\n",
+    "            .storage())\n",
+    "\n",
+    "    def persistent_load(saved_id):\n",
+    "        assert isinstance(saved_id, tuple)\n",
+    "        typename = _maybe_decode_ascii(saved_id[0])\n",
+    "        data = saved_id[1:]\n",
+    "\n",
+    "        assert typename == 'storage', \\\n",
+    "            f\"Unknown typename for persistent_load, expected 'storage' but got '{typename}'\"\n",
+    "        storage_type, key, location, numel = data\n",
+    "        if storage_type is torch._UntypedStorage:\n",
+    "            dtype = torch.uint8\n",
+    "        else:\n",
+    "            dtype = storage_type.dtype\n",
+    "\n",
+    "        if key not in loaded_storages:\n",
+    "            # Original PyTorch code passed in the number of bytes for the `numel`\n",
+    "            # argument here for some reason.\n",
+    "            load_tensor(dtype, numel, key, _maybe_decode_ascii(location))\n",
+    "\n",
+    "        return loaded_storages[key]\n",
+    "\n",
+    "    load_module_mapping: Dict[str, str] = {\n",
+    "        # See https://github.com/pytorch/pytorch/pull/51633\n",
+    "        'torch.tensor': 'torch._tensor'\n",
+    "    }\n",
+    "\n",
+    "    # Need to subclass Unpickler instead of directly monkey-patching the find_class method\n",
+    "    # because it's marked readonly in pickle.\n",
+    "    # The type: ignore is because mypy can't statically determine the type of this class.\n",
+    "    class UnpicklerWrapper(pickle_module.Unpickler):  # type: ignore[name-defined]\n",
+    "        # from https://stackoverflow.com/questions/13398462/unpickling-python-objects-with-a-changed-module-path/13405732\n",
+    "        # Lets us override the imports that pickle uses when unpickling an object.\n",
+    "        # This is useful for maintaining BC if we change a module path that tensor instantiation relies on.\n",
+    "        def find_class(self, mod_name, name):\n",
+    "            if type(name) is str and 'Storage' in name:\n",
+    "                try:\n",
+    "                    return torch.serialization.StorageType(name)\n",
+    "                except KeyError:\n",
+    "                    pass\n",
+    "            mod_name = load_module_mapping.get(mod_name, mod_name)\n",
+    "            return super().find_class(mod_name, name)\n",
+    "\n",
+    "    # Load the data (which may in turn use `persistent_load` to load tensors)\n",
+    "    data_file = io.BytesIO(pickled_data_array.tobytes())\n",
+    "\n",
+    "    unpickler = UnpicklerWrapper(data_file, **pickle_load_args)\n",
+    "    unpickler.persistent_load = persistent_load\n",
+    "    result = unpickler.load()\n",
+    "\n",
+    "    torch._utils._validate_loaded_sparse_tensors()\n",
+    "\n",
+    "    return result\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "193a3f54-fcb1-405d-9a82-89f11f12b65e",
+   "metadata": {},
+   "source": [
+    "We can use this `zero_copy_load()` function to load a second instance of BERT:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "f240bd2d-2cc4-48a9-8901-1ec615a6dfc8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bert_2 = zero_copy_load(h5_file_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9781d223-76a2-4590-96a5-d376f9658f10",
+   "metadata": {},
+   "source": [
+    "This load operation takes about 30-40 msec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "a961564a-56b0-41c7-89b1-7f7900d75472",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21.6 ms ± 6.86 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit zero_copy_load(h5_file_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03e8f43f-4b61-42ae-a1a7-6806168ce332",
+   "metadata": {},
+   "source": [
+    "Most of that wall-clock time goes to memory-mapping the HDF5 file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "0d7174ee-590e-402e-badc-eef0f3d32e62",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.25 ms, sys: 10.4 ms, total: 11.6 ms\n",
+      "Wall time: 28.8 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "raw_file = open(h5_file_name, 'rb')\n",
+    "_ = mmap.mmap(raw_file.fileno(), 0, access=mmap.ACCESS_COPY)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61e1cf5e-c2ef-4f38-bbea-64c0a2e36f10",
+   "metadata": {},
+   "source": [
+    "This speed compares quite favorably to loading with `torch.load()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "92bd7113-f467-4a66-b923-a8ed6ff4c8aa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "148 ms ± 3.89 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit torch.load('outputs/bert.pt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4eb0e410-5cac-4712-852f-b23396af4d36",
+   "metadata": {},
+   "source": [
+    "We can verify that the model loaded with `zero_copy_load()` produces the same answer as the original:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "da325842-fb61-45ee-a71c-58b741302dba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original model's output:\n",
+      "tensor([[[-0.4056, -0.3897, -0.3079,  ..., -0.5104,  0.2806,  0.7274],\n",
+      "         [-0.6331, -0.5107, -0.5133,  ..., -0.5693,  0.9497,  0.1506],\n",
+      "         [-0.3115, -0.7275,  0.1119,  ..., -0.3893,  0.6364,  0.6212],\n",
+      "         ...,\n",
+      "         [ 0.0106, -0.1030,  0.0220,  ..., -0.3178, -0.0998,  0.0148],\n",
+      "         [ 0.5781,  0.1131, -0.6878,  ...,  0.3539, -0.4097, -0.2768],\n",
+      "         [ 0.0636, -0.2789, -0.3596,  ...,  0.5591, -0.9456,  0.1195]]])\n",
+      "\n",
+      "Model output after zero-copy model loading:\n",
+      "tensor([[[-0.4056, -0.3897, -0.3079,  ..., -0.5104,  0.2806,  0.7274],\n",
+      "         [-0.6331, -0.5107, -0.5133,  ..., -0.5693,  0.9497,  0.1506],\n",
+      "         [-0.3115, -0.7275,  0.1119,  ..., -0.3893,  0.6364,  0.6212],\n",
+      "         ...,\n",
+      "         [ 0.0106, -0.1030,  0.0220,  ..., -0.3178, -0.0998,  0.0148],\n",
+      "         [ 0.5781,  0.1131, -0.6878,  ...,  0.3539, -0.4097, -0.2768],\n",
+      "         [ 0.0636, -0.2789, -0.3596,  ...,  0.5591, -0.9456,  0.1195]]])\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_text = 'This is an example input sentence.'\n",
+    "tokenizer = transformers.BertTokenizerFast.from_pretrained(\n",
+    "    'bert-base-uncased')\n",
+    "test_tokens = tokenizer(test_text, return_tensors=\"pt\")\n",
+    "\n",
+    "# Run the original model and the copy that we just loaded\n",
+    "with torch.inference_mode():\n",
+    "    print(\"Original model's output:\")\n",
+    "    print(bert(**test_tokens).last_hidden_state)\n",
+    "    print(\"\\nModel output after zero-copy model loading:\")\n",
+    "    print(bert_2(**test_tokens).last_hidden_state)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19e01ace-1880-48a2-94ec-b2e8914d3b5a",
+   "metadata": {},
+   "source": [
+    "There is one key diference, though: All the weights in the copy that we've loaded with `zero_copy_load()` are in a single memory-mapped region. \n",
+    "That memory-mapped region is shared across processes, so if this process and others on the same machine load many copies of the model, the model's weights will only be stored once in memory across the entire machine.\n",
+    "\n",
+    "Watch what happens to the Python process's heap size when we load 1000 copies of `bert-base-uncased` using `zero_copy_load()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "cb20e5f9-4836-464d-99d4-8b6e2ebb92be",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Memory usage before loading 1000 models: 1619.505859375 MB\n",
+      "Memory usage after loading 1000 models: 1739.984375 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "def memory_in_mb() -> int:\n",
+    "    return psutil.Process(os.getpid()).memory_info().rss / 2 / 1048576\n",
+    "\n",
+    "mb_before = memory_in_mb()\n",
+    "print(f'Memory usage before loading 1000 models: {mb_before} MB')\n",
+    "many_berts = [\n",
+    "    zero_copy_load(h5_file_name) for i in range(1000)\n",
+    "]\n",
+    "mb_after = memory_in_mb()\n",
+    "print(f'Memory usage after loading 1000 models: {mb_after} MB')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53c3143c-1305-4523-a768-3e7cc689bceb",
+   "metadata": {},
+   "source": [
+    "With the weights living in shared memory, each copy of BERT requires only a small slice of process memory to hold its Python objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "b5436b92-75c3-468f-bf6c-10bd819ab71f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Megabytes of process memory per copy of bert-base-uncased: 0.120\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'Megabytes of process memory per copy of bert-base-uncased: '\n",
+    "      f'{(mb_after - mb_before)/1000:0.3f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a53d2a1d-b447-4a59-99f7-58f4a28e1bcf",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This change set adds a new notebook containing a proof-of-concept implementation of zero-copy loading from HDF5 files. The process used involves converting a model serialized with `torch.save()` from zip format to HDF5, then memory-mapping the entireHDF5 file and loading weights directly out of the memory-mapped region.